### PR TITLE
Pointing at the latest engine version by default

### DIFF
--- a/optional.tf
+++ b/optional.tf
@@ -18,7 +18,7 @@ variable "schedule" {
 variable "runtime_version" {
   description = "Specifies the runtime version to use for the canary. For a list of valid runtime versions, see Canary Runtime Versions."
   type        = string
-  default     = "syn-nodejs-puppeteer-7.0"
+  default     = "syn-nodejs-puppeteer-11.0"
 }
 
 variable "execution_role_arn" {


### PR DESCRIPTION
Looks like we're way behind here, so I'm making the default the latest.